### PR TITLE
Add support for global case studies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # db file
 db.test.sqlite
+database
 
 # compiled output
 /dist

--- a/src/studies/dto/create-study.dto.ts
+++ b/src/studies/dto/create-study.dto.ts
@@ -1,6 +1,6 @@
 import { IsArray, IsBoolean, IsString, IsUUID } from 'class-validator';
 
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateStudyDto {
   @ApiProperty({
@@ -31,7 +31,7 @@ export class CreateStudyDto {
   @IsBoolean()
   supportsRecording;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'The ids of the country code associated to this study',
     type: [String],
   })

--- a/src/studies/studies.service.ts
+++ b/src/studies/studies.service.ts
@@ -126,6 +126,11 @@ export class StudiesService {
         },
         form: true,
       },
+      order: {
+        countryCodes: {
+          countryName: 'ASC',
+        },
+      },
     });
 
     return mapStudiesToDtos(foundStudies);

--- a/src/studies/studies.service.ts
+++ b/src/studies/studies.service.ts
@@ -6,7 +6,7 @@ import {
 import { CreateStudyDto } from './dto/create-study.dto';
 import { UpdateStudyDto } from './dto/update-study.dto';
 import { Study } from './entities/study.entity';
-import { Repository } from 'typeorm';
+import { FindOperator, IsNull, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CountryCodesService } from 'src/countryCodes/country-codes.service';
 import { isDefined } from 'class-validator';
@@ -20,6 +20,7 @@ import {
   mapStudyEntityToDto,
 } from './mappers/mapEntitiesToDto';
 import { GeolocationService } from 'src/geolocation/geo-location.service';
+import { CountryCodeDto } from 'src/countryCodes/dtos/country-code.dto';
 
 @Injectable()
 export class StudiesService {
@@ -36,12 +37,16 @@ export class StudiesService {
   ) {}
 
   async create(headerApiKey: string, createStudyDto: CreateStudyDto) {
-    const countryCodes = await this.countryCodeService.findAllById(
-      createStudyDto.countryCodeIds,
-    );
-
-    if (!countryCodes.length) {
-      throw new BadRequestException('No Country Codes with the given id exist');
+    let countryCodes: CountryCodeDto[] = [];
+    if (createStudyDto.countryCodeIds.length) {
+      countryCodes = await this.countryCodeService.findAllById(
+        createStudyDto.countryCodeIds,
+      );
+      if (!countryCodes.length) {
+        throw new BadRequestException(
+          'No Country Codes with the given id exist',
+        );
+      }
     }
 
     const policies = await this.policiesService.findAllById(
@@ -61,18 +66,20 @@ export class StudiesService {
     const savedApiKey = await this.apiKeyRepository.findOne({
       where: { key: headerApiKey },
     });
-
-    const createdStudy = await this.studyRepository.create({
+    const createStudyOptions = {
       name: createStudyDto.name,
       description: createStudyDto.description,
       isActive: createStudyDto.isActive,
       supportsRecording: createStudyDto.supportsRecording,
-      countryCodes,
       policies,
       onboarding,
       form,
       createdBy: savedApiKey,
-    });
+    };
+    if (countryCodes.length) {
+      createStudyOptions['countryCodes'] = countryCodes;
+    }
+    const createdStudy = await this.studyRepository.create(createStudyOptions);
 
     const savedStudy = await this.studyRepository.save(createdStudy);
 
@@ -89,16 +96,27 @@ export class StudiesService {
     const userCountryCode =
       await this.geolocationService.getCountryCodeByIpAddress(ipAddress);
 
-    const areStudiesAvailable = await this.studyRepository.exist({
-      where: { countryCodes: { code: userCountryCode } },
-    });
-
-    if (!areStudiesAvailable) {
-      return this.findAll();
+    const where: {
+      countryCodes: {
+        code?: string;
+        id?: FindOperator<any>;
+      };
+    }[] = [
+      {
+        countryCodes: {
+          id: IsNull(),
+        },
+      },
+    ];
+    if (userCountryCode) {
+      where.unshift({
+        countryCodes: {
+          code: userCountryCode,
+        },
+      });
     }
-
     const foundStudies = await this.studyRepository.find({
-      where: { countryCodes: { code: userCountryCode } },
+      where,
       relations: {
         countryCodes: true,
         policies: true,

--- a/src/utils/fake-repository.util.ts
+++ b/src/utils/fake-repository.util.ts
@@ -10,6 +10,10 @@ import { arrayNotEmpty, isArray, isEmpty } from 'class-validator';
 import { isFilledArray } from './isFilledArray';
 import { randomUuidv4 } from './generate-uuid';
 
+const uniqueValues = (value, index, array) => {
+  return array.indexOf(value) === index;
+};
+
 export function getFakeEntityRepository<TEntity>(): Partial<
   Repository<TEntity>
 > {
@@ -17,59 +21,78 @@ export function getFakeEntityRepository<TEntity>(): Partial<
 
   const filterEntities = (options?: FindManyOptions<TEntity>) => {
     const entityKeys = Object.keys(entities.at(0));
-    let filteredEntities = [];
-    const [first] = Object.keys(options.where);
-    const condition = options.where[first];
 
-    if (!entityKeys.includes(first)) {
-      const [firstConditionKey] = Object.keys(condition);
+    const filterEntitiesSingleCondition = (
+      entities: TEntity[],
+      where: FindOptionsWhere<TEntity>,
+    ) => {
+      const [first] = Object.keys(where);
+      const condition = where[first];
+      let filteredEntities: TEntity[] = [];
 
-      filteredEntities = entities.filter((entity) => {
+      if (!entityKeys.includes(first)) {
+        const [firstConditionKey] = Object.keys(condition);
+
+        filteredEntities = entities.filter((entity) => {
+          if (
+            condition?.[firstConditionKey].type === 'isNull' &&
+            isEmpty(entity?.[first])
+          ) {
+            return true;
+          }
+          return false;
+        });
+      }
+
+      for (const key of entityKeys) {
+        if (!where[key]) {
+          continue;
+        }
+
+        const [firstWhereKey] = Object.keys(where[key]);
+        const firstWhereCondition = where[key];
+
         if (
-          condition?.[firstConditionKey].type === 'isNull' &&
-          isEmpty(entity?.[first])
+          firstWhereCondition[firstWhereKey] !== null &&
+          firstWhereCondition[firstWhereKey].type === 'isNull'
         ) {
-          return true;
+          filteredEntities = entities.filter(
+            (entity) =>
+              !isFilledArray(entity[key]) || !arrayNotEmpty(entity[key]),
+          );
+          continue;
         }
-        return false;
-      });
-    }
 
-    for (const key of entityKeys) {
-      if (!options.where[key]) {
-        continue;
+        filteredEntities = entities.filter((entity) => {
+          if (isArray(entity[key])) {
+            return entity[key].find((foundEntity) => {
+              if (!where[key]?.[firstWhereKey]) {
+                return true;
+              }
+              return (
+                foundEntity?.[firstWhereKey] === where[key]?.[firstWhereKey]
+              );
+            });
+          }
+          return entity[key]?.[firstWhereKey] === where[key]?.[firstWhereKey];
+        });
       }
 
-      const [firstWhereKey] = Object.keys(options.where[key]);
-      const firstWhereCondition = options.where[key];
-
-      if (
-        firstWhereCondition[firstWhereKey] !== null &&
-        firstWhereCondition[firstWhereKey].type === 'isNull'
-      ) {
-        filteredEntities = entities.filter(
-          (entity) =>
-            !isFilledArray(entity[key]) || !arrayNotEmpty(entity[key]),
-        );
-        continue;
-      }
-
-      filteredEntities = entities.filter((entity) => {
-        if (isArray(entity[key])) {
-          return entity[key].find((foundEntity) => {
-            if (!options.where[key]?.[firstWhereKey]) {
-              return true;
-            }
-            return (
-              foundEntity?.[firstWhereKey] ===
-              options.where[key]?.[firstWhereKey]
-            );
-          });
-        }
-        return (
-          entity[key]?.[firstWhereKey] === options.where[key]?.[firstWhereKey]
-        );
-      });
+      return filteredEntities;
+    };
+    const whereIsArray = isArray(options.where);
+    let filteredEntities: TEntity[] = [];
+    if (whereIsArray) {
+      const nestedFilteredEntities = (
+        options.where as FindOptionsWhere<TEntity>[]
+      ).map((where) => filterEntitiesSingleCondition(entities, where));
+      // Flatten and deduplicate multiple where conditions
+      filteredEntities = nestedFilteredEntities.flat().filter(uniqueValues);
+    } else {
+      filteredEntities = filterEntitiesSingleCondition(
+        entities,
+        options.where as FindOptionsWhere<TEntity>,
+      );
     }
 
     return filteredEntities;


### PR DESCRIPTION
* Make `countryCodes` optional when creating case studies
* A study with no country codes is assumed to be global
* Update the `/studies/by-country-code/` endpoint to return studies for the given country + global studies
* Update unit tests
* Fix fake-repository to handle multiple `where` conditions as `OR`

Sample payload to create a global study, tested with staging values.

```json
{
  "name": "Global Study",
  "description": "a test global study",
  "isActive": true,
  "supportsRecording": true,
  "countryCodeIds": [],
  "policyIds": [
    "e462bd7b-9b17-4088-996e-a484d75cce4e"
  ],
  "onboardingId": "a9d81844-1ae3-4a94-ad22-d096ffed655f",
  "formId": "6f5c271d-e7c0-46c2-8692-ff34c2494127"
}
```